### PR TITLE
Rough script to get the commits along with lines changed info.

### DIFF
--- a/get_commits_with_lines_changed.sh
+++ b/get_commits_with_lines_changed.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DIR=mp4parse-rust
+test -d ${DIR} || git clone https://github.com/mozilla/${DIR}
+pushd ${DIR}
+git log --pretty=format:%h,%an,%at --shortstat | awk '/^$/ {if (x) print x"\n"; x=""; next} {x=(!x)?$0:x","$0}END{print x"\n"}' > ../commits.csv
+popd


### PR DESCRIPTION
Bit nasty since if there are no lines inserted or deleted,
git --shortstat doesn't print that.

The awk command just joins the lines so it looks like a csv.
